### PR TITLE
Configrable threshold for showing low entropy warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ plugins:
         #reload_scripts:
         #  - '#theme'
         password_file: 'passwords.yml' # file with password inventory
+        threshold_warning_min_entropy: 100 # warn if password entropy is below this value
         #kdf_pow: 4 # default for crypto-js: 4, default for webcrypto: 5
         sign_files: 'encryptcontent-plugin.json' # save ed25519 signatures here
         #hash_filenames: # add hash to file names of assets (to make them impossible to guess

--- a/documentation/docs/usage.md
+++ b/documentation/docs/usage.md
@@ -226,6 +226,7 @@ plugins:
         #reload_scripts:
         #  - '#theme'
         password_file: 'passwords.yml' # file with password inventory
+        threshold_warning_min_entropy: 100 # warn if password entropy is below this value
         #kdf_pow: 4 # default for crypto-js: 4, default for webcrypto: 5
         sign_files: 'encryptcontent-plugin.json' # save ed25519 signatures here
         #hash_filenames: # add hash to file names of assets (to make them impossible to guess

--- a/encryptcontent/plugin.py
+++ b/encryptcontent/plugin.py
@@ -89,6 +89,7 @@ class encryptContentPlugin(BasePlugin):
         ('sharelinks', config_options.Type(bool, default=False)),
         ('sharelinks_incomplete', config_options.Type(bool, default=False)),
         ('sharelinks_output', config_options.Type(string_types, default='sharelinks.txt')),
+        ('threshold_warning_min_entropy', config_options.Type(int, default=100)),
         # default features enabled
         ('arithmatex', config_options.Type(bool, default=None)),
         ('hljs', config_options.Type(bool, default=None)),
@@ -1165,7 +1166,7 @@ class encryptContentPlugin(BasePlugin):
                 os._exit(1)
             logger.info('Modified search_index.')
 
-        if self.setup['min_enttropy_spied_on'] < 100 and self.setup['min_enttropy_spied_on'] > 0:
+        if self.setup['min_enttropy_spied_on'] < self.config['threshold_warning_min_entropy'] and self.setup['min_enttropy_spied_on'] > 0:
             logger.warning('mkdocs-encryptcontent-plugin will always be vulnerable to brute-force attacks!'
                            ' Your weakest password only got {spied_on} bits of entropy, if someone watched you while typing'
                            ' (and a maximum of {secret} bits total)!'.format(spied_on = math.ceil(self.setup['min_enttropy_spied_on']), secret = math.ceil(self.setup['min_enttropy_secret']))


### PR DESCRIPTION
This warning shows if you have a weak password with an entropy lower than 100.

```
WARNING -  mkdocs-encryptcontent-plugin will always be vulnerable to brute-force attacks! Your weakest password only got 89 bits of entropy, if someone watched you while typing (and a maximum of 97 bits total)!
```

This threshold is now configurable (default is 100):

```yml
plugins:
  - encryptcontent:
      threshold_warning_min_entropy: 50
```